### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,14 +264,14 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "mf1"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "mf1-macros",
 ]
 
 [[package]]
 name = "mf1-macros"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "convert_case",
  "mf1-parser",
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "mf1-parser"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "icu_plurals",
  "logos",

--- a/crates/mf1-macros/CHANGELOG.md
+++ b/crates/mf1-macros/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1](https://github.com/JadedBlueEyes/messageformat/compare/mf1-macros-v0.1.0...mf1-macros-v0.1.1) - 2024-07-12
+
+### Other
+- Fill out changelogs and configure git-cliff
+
 ## [mf1-macros-v0.1.0] - 2024-07-12
 
 ### Bug Fixes

--- a/crates/mf1-macros/Cargo.toml
+++ b/crates/mf1-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mf1-macros"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Macros for the mf1 crate"
@@ -10,7 +10,7 @@ proc-macro = true
 
 [dependencies]
 convert_case = "0.6.0"
-mf1-parser = { version = "0.1.0", path = "../mf1-parser" }
+mf1-parser = { version = "0.1.1", path = "../mf1-parser" }
 proc-macro2 = "1.0.86"
 quote = "1.0.36"
 serde = { version = "1.0.203", features = ["derive"] }

--- a/crates/mf1-parser/CHANGELOG.md
+++ b/crates/mf1-parser/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1](https://github.com/JadedBlueEyes/messageformat/compare/mf1-parser-v0.1.0...mf1-parser-v0.1.1) - 2024-07-12
+
+### Other
+- Fill out changelogs and configure git-cliff
+
 ## [mf1-parser-v0.1.0] - 2024-07-12
 
 ### Bug Fixes

--- a/crates/mf1-parser/Cargo.toml
+++ b/crates/mf1-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mf1-parser"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Parse ICU MessageFormat 1 syntax"

--- a/crates/mf1/CHANGELOG.md
+++ b/crates/mf1/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1](https://github.com/JadedBlueEyes/messageformat/compare/mf1-v0.1.0...mf1-v0.1.1) - 2024-07-12
+
+### Other
+- Fill out changelogs and configure git-cliff
+
 ## [mf1-v0.1.0] - 2024-07-12
 
 ### Documentation

--- a/crates/mf1/Cargo.toml
+++ b/crates/mf1/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "mf1"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Use ICU Messageformat 1 to internationalise your apps"
 
 [dependencies]
 
-mf1-macros = { path = "../mf1-macros", version = "0.1.0", optional = true}
+mf1-macros = { path = "../mf1-macros", version = "0.1.1", optional = true}
 
 [features]
 

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-mf1 = { version = "0.1.0", path = "../../crates/mf1" }
+mf1 = { version = "0.1.1", path = "../../crates/mf1" }
 
 [package.metadata.mf1]
 locales = ["en", "es"]

--- a/examples/kitchen-sink/Cargo.toml
+++ b/examples/kitchen-sink/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 expect-test = "1.5.0"
 
-mf1 = { version = "0.1.0", path = "../../crates/mf1" }
+mf1 = { version = "0.1.1", path = "../../crates/mf1" }
 
 [package.metadata.mf1]
 locales = ["en", "es"]


### PR DESCRIPTION
## 🤖 New release
* `mf1`: 0.1.0 -> 0.1.1
* `mf1-macros`: 0.1.0 -> 0.1.1
* `mf1-parser`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `mf1`
<blockquote>

## [0.1.1](https://github.com/JadedBlueEyes/messageformat/compare/mf1-v0.1.0...mf1-v0.1.1) - 2024-07-12

### Other
- Fill out changelogs and configure git-cliff
</blockquote>

## `mf1-macros`
<blockquote>

## [0.1.1](https://github.com/JadedBlueEyes/messageformat/compare/mf1-macros-v0.1.0...mf1-macros-v0.1.1) - 2024-07-12

### Other
- Fill out changelogs and configure git-cliff
</blockquote>

## `mf1-parser`
<blockquote>

## [0.1.1](https://github.com/JadedBlueEyes/messageformat/compare/mf1-parser-v0.1.0...mf1-parser-v0.1.1) - 2024-07-12

### Other
- Fill out changelogs and configure git-cliff
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).