### PR TITLE
chore: release v0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,14 +264,14 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "mf1"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "mf1-macros",
 ]
 
 [[package]]
 name = "mf1-macros"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "convert_case",
  "mf1-parser",

--- a/crates/mf1-macros/CHANGELOG.md
+++ b/crates/mf1-macros/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+
+## [0.1.5](https://github.com/JadedBlueEyes/messageformat/compare/mf1-macros-v0.1.4...mf1-macros-v0.1.5) - 2024-08-22
+
+### Bug Fixes
+
+- Allow multiple interpolation values in [`3228ee1`](https://github.com/JadedBlueEyes/messageformat/commit/3228ee11e3a78cc407552ca6f43e5e96b38e1a9b)
+
 ## [0.1.4](https://github.com/JadedBlueEyes/messageformat/compare/mf1-macros-v0.1.3...mf1-macros-v0.1.4) - 2024-08-02
 
 ### Documentation

--- a/crates/mf1-macros/Cargo.toml
+++ b/crates/mf1-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mf1-macros"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Macros for the mf1 crate"

--- a/crates/mf1/CHANGELOG.md
+++ b/crates/mf1/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+
+## [0.1.5](https://github.com/JadedBlueEyes/messageformat/compare/mf1-v0.1.4...mf1-v0.1.5) - 2024-08-22
+
+### Miscellaneous Tasks
+
+- Updated the following local packages: mf1-macros in [`0000000`](https://github.com/JadedBlueEyes/messageformat/commit/0000000)
+
 ## [0.1.4](https://github.com/JadedBlueEyes/messageformat/compare/mf1-v0.1.3...mf1-v0.1.4) - 2024-08-02
 
 ### Documentation

--- a/crates/mf1/CHANGELOG.md
+++ b/crates/mf1/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Miscellaneous Tasks
 
-- Updated the following local packages: mf1-macros in [`0000000`](https://github.com/JadedBlueEyes/messageformat/commit/0000000)
+- Updated the following local packages: mf1-macros
 
 ## [0.1.4](https://github.com/JadedBlueEyes/messageformat/compare/mf1-v0.1.3...mf1-v0.1.4) - 2024-08-02
 

--- a/crates/mf1/Cargo.toml
+++ b/crates/mf1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mf1"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Use ICU MessageFormat 1 to internationalise your apps"
@@ -10,7 +10,7 @@ homepage = "https://github.com/JadedBlueEyes/messageformat/tree/main/crates/mf1"
 
 [dependencies]
 
-mf1-macros = { path = "../mf1-macros", version = "0.1.4", optional = true}
+mf1-macros = { path = "../mf1-macros", version = "0.1.5", optional = true}
 
 [features]
 

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-mf1 = { version = "0.1.4", path = "../../crates/mf1" }
+mf1 = { version = "0.1.5", path = "../../crates/mf1" }
 
 [package.metadata.mf1]
 locales = ["en", "es"]

--- a/examples/kitchen-sink/Cargo.toml
+++ b/examples/kitchen-sink/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 expect-test = "1.5.0"
 
-mf1 = { version = "0.1.4", path = "../../crates/mf1" }
+mf1 = { version = "0.1.5", path = "../../crates/mf1" }
 
 [package.metadata.mf1]
 locales = ["en", "es"]


### PR DESCRIPTION
## 🤖 New release
* `mf1-macros`: 0.1.4 -> 0.1.5
* `mf1`: 0.1.4 -> 0.1.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `mf1-macros`
<blockquote>

## [0.1.5](https://github.com/JadedBlueEyes/messageformat/compare/mf1-macros-v0.1.4...mf1-macros-v0.1.5) - 2024-08-22

### Bug Fixes

- Allow multiple interpolation values in [`3228ee1`](https://github.com/JadedBlueEyes/messageformat/commit/3228ee11e3a78cc407552ca6f43e5e96b38e1a9b)
</blockquote>

## `mf1`
<blockquote>

## [0.1.5](https://github.com/JadedBlueEyes/messageformat/compare/mf1-v0.1.4...mf1-v0.1.5) - 2024-08-22

### Miscellaneous Tasks

- Updated the following local packages: mf1-macros in [`0000000`](https://github.com/JadedBlueEyes/messageformat/commit/0000000)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).