### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,14 +265,14 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "mf1"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "mf1-macros",
 ]
 
 [[package]]
 name = "mf1-macros"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "convert_case",
  "mf1-parser",
@@ -287,7 +287,7 @@ dependencies = [
 
 [[package]]
 name = "mf1-parser"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "icu_plurals",
  "logos",

--- a/crates/mf1-macros/CHANGELOG.md
+++ b/crates/mf1-macros/CHANGELOG.md
@@ -6,6 +6,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 
 
+## [0.1.7](https://github.com/JadedBlueEyes/messageformat/compare/mf1-macros-v0.1.6...mf1-macros-v0.1.7) - 2025-05-11
+
+### Miscellaneous Tasks
+
+- Update breaking dep versions in [`62030c9`](https://github.com/JadedBlueEyes/messageformat/commit/62030c922e62fcf7fa7ea2c4348312fb7e253568)
+- More explicitly transform to proc_macro2 tokens in [`bb14afe`](https://github.com/JadedBlueEyes/messageformat/commit/bb14afe1b0ea35e0c68739fc47051d658bfac826)
+- Fix typos in [`6fe2c13`](https://github.com/JadedBlueEyes/messageformat/commit/6fe2c13120f6ed2d254778e0422a3960ed4d2ea0)
+
+
+
 ## [0.1.6](https://github.com/JadedBlueEyes/messageformat/compare/mf1-macros-v0.1.5...mf1-macros-v0.1.6) - 2024-09-13
 
 ### Miscellaneous Tasks

--- a/crates/mf1-macros/Cargo.toml
+++ b/crates/mf1-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mf1-macros"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Macros for the mf1 crate"
@@ -14,7 +14,7 @@ proc-macro = true
 
 [dependencies]
 convert_case = "0.8.0"
-mf1-parser = { version = "0.1.5", path = "../mf1-parser" }
+mf1-parser = { version = "0.1.6", path = "../mf1-parser" }
 proc-macro2 = "1.0.86"
 quote = "1.0.36"
 serde = { version = "1.0.203", features = ["derive"] }

--- a/crates/mf1-parser/CHANGELOG.md
+++ b/crates/mf1-parser/CHANGELOG.md
@@ -6,6 +6,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 
 
+## [0.1.6](https://github.com/JadedBlueEyes/messageformat/compare/mf1-parser-v0.1.5...mf1-parser-v0.1.6) - 2025-05-11
+
+### Miscellaneous Tasks
+
+- Update breaking dep versions in [`62030c9`](https://github.com/JadedBlueEyes/messageformat/commit/62030c922e62fcf7fa7ea2c4348312fb7e253568)
+- Fix typos in [`6fe2c13`](https://github.com/JadedBlueEyes/messageformat/commit/6fe2c13120f6ed2d254778e0422a3960ed4d2ea0)
+
+
+
 ## [0.1.5](https://github.com/JadedBlueEyes/messageformat/compare/mf1-parser-v0.1.4...mf1-parser-v0.1.5) - 2024-09-13
 
 ### Miscellaneous Tasks

--- a/crates/mf1-parser/Cargo.toml
+++ b/crates/mf1-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mf1-parser"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Parse ICU MessageFormat 1 syntax"

--- a/crates/mf1/CHANGELOG.md
+++ b/crates/mf1/CHANGELOG.md
@@ -6,6 +6,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 
 
+## [0.1.7](https://github.com/JadedBlueEyes/messageformat/compare/mf1-v0.1.6...mf1-v0.1.7) - 2025-05-11
+
+### Miscellaneous Tasks
+
+- Fix typos in [`6fe2c13`](https://github.com/JadedBlueEyes/messageformat/commit/6fe2c13120f6ed2d254778e0422a3960ed4d2ea0)
+
+
+
 ## [0.1.6](https://github.com/JadedBlueEyes/messageformat/compare/mf1-v0.1.5...mf1-v0.1.6) - 2024-09-13
 
 ### Miscellaneous Tasks

--- a/crates/mf1/Cargo.toml
+++ b/crates/mf1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mf1"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Use ICU MessageFormat 1 to internationalise your apps"
@@ -13,7 +13,7 @@ homepage = "https://github.com/JadedBlueEyes/messageformat/tree/main/crates/mf1"
 
 [dependencies]
 
-mf1-macros = { path = "../mf1-macros", version = "0.1.6", optional = true}
+mf1-macros = { path = "../mf1-macros", version = "0.1.7", optional = true}
 
 [features]
 

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-mf1 = { version = "0.1.6", path = "../../crates/mf1" }
+mf1 = { version = "0.1.7", path = "../../crates/mf1" }
 
 [package.metadata.mf1]
 locales = ["en", "es"]

--- a/examples/kitchen-sink/Cargo.toml
+++ b/examples/kitchen-sink/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 expect-test = "1.5.0"
 
-mf1 = { version = "0.1.6", path = "../../crates/mf1" }
+mf1 = { version = "0.1.7", path = "../../crates/mf1" }
 
 [package.metadata.mf1]
 locales = ["en", "es"]


### PR DESCRIPTION



## 🤖 New release

* `mf1-parser`: 0.1.5 -> 0.1.6 (✓ API compatible changes)
* `mf1-macros`: 0.1.6 -> 0.1.7
* `mf1`: 0.1.6 -> 0.1.7 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `mf1-parser`

<blockquote>

## [0.1.6](https://github.com/JadedBlueEyes/messageformat/compare/mf1-parser-v0.1.5...mf1-parser-v0.1.6) - 2025-05-11

### Miscellaneous Tasks

- Update breaking dep versions in [`62030c9`](https://github.com/JadedBlueEyes/messageformat/commit/62030c922e62fcf7fa7ea2c4348312fb7e253568)
- Fix typos in [`6fe2c13`](https://github.com/JadedBlueEyes/messageformat/commit/6fe2c13120f6ed2d254778e0422a3960ed4d2ea0)
</blockquote>

## `mf1-macros`

<blockquote>

## [0.1.7](https://github.com/JadedBlueEyes/messageformat/compare/mf1-macros-v0.1.6...mf1-macros-v0.1.7) - 2025-05-11

### Miscellaneous Tasks

- Update breaking dep versions in [`62030c9`](https://github.com/JadedBlueEyes/messageformat/commit/62030c922e62fcf7fa7ea2c4348312fb7e253568)
- More explicitly transform to proc_macro2 tokens in [`bb14afe`](https://github.com/JadedBlueEyes/messageformat/commit/bb14afe1b0ea35e0c68739fc47051d658bfac826)
- Fix typos in [`6fe2c13`](https://github.com/JadedBlueEyes/messageformat/commit/6fe2c13120f6ed2d254778e0422a3960ed4d2ea0)
</blockquote>

## `mf1`

<blockquote>

## [0.1.7](https://github.com/JadedBlueEyes/messageformat/compare/mf1-v0.1.6...mf1-v0.1.7) - 2025-05-11

### Miscellaneous Tasks

- Fix typos in [`6fe2c13`](https://github.com/JadedBlueEyes/messageformat/commit/6fe2c13120f6ed2d254778e0422a3960ed4d2ea0)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).